### PR TITLE
Updating url to use zip instead

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6,7 +6,7 @@
   "Versions": [
     {
       "Version": "0.0.1",
-      "Url": "https://github.com/usfbih8u/micro-autocomplete-tooltip/archive/0.0.1.tar.gz",
+      "Url": "https://github.com/usfbih8u/micro-autocomplete-tooltip/archive/0.0.1.zip",
       "Require": {
         "micro": ">=2.0.14"
       }


### PR DESCRIPTION
micro plugin can't use tar.gz. Updating to use zip instead. 