### PR TITLE
Fixing require not working when being downloaded as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ You can **change the colors** inside `colorschemes/autocomplete-tooltip.micro`.
 
 ## 📦 Installation
 
-⚠️ **Do NOT change the name of the plugin directory `micro-autocomplete-tooltip`**.  It is used as a prefix to avoid path collisions in `package.path` when requiring modules.
+⚠️ **Do NOT change the name of the plugin directory**.  It is used as a prefix to avoid path collisions in `package.path` when requiring modules.
+
+You can install this from the [unofficial micro plugin channel](https://github.com/Neko-Box-Coder/unofficial-plugin-channel) by adding the following to your `settings.json`
+```json
+"pluginchannels": [
+    "https://raw.githubusercontent.com/Neko-Box-Coder/unofficial-plugin-channel/main/channel.json"
+]
+```
+
+Then do `micro -plugin install autocomplete_tooltip`
+
+Alternatively, you can clone this directly to your `.config/micro/plug`
 
 In Linux, you can clone the repo anywhere and create a symlink inside `.config/micro/plug` using the `ENABLE_FOR_MICRO.sh` script.

--- a/autocomplete_tooltip.lua
+++ b/autocomplete_tooltip.lua
@@ -23,7 +23,13 @@ function init()
         package.path = plugDirPath .. package.path
     end
     config.AddRuntimeFile(plugName, config.RTSyntax, "syntax/autocomplete-tooltip.yaml")
-    TooltipModule = require('micro-autocomplete-tooltip.tooltip')
+
+    local ok, module = pcall(require, 'micro-autocomplete-tooltip.tooltip')
+    if ok then -- Cloned as micro-autocomplete-tooltip
+        TooltipModule = require('micro-autocomplete-tooltip.tooltip')
+    else -- Downloaded from Micro as autocomplete_tooltip
+        TooltipModule = require(plugName .. ".tooltip")
+    end
 end
 
 ---@class (exact) Autocomplete Keeps the state of the plugin.


### PR DESCRIPTION
When the plugin is downloaded from micro instead of cloned, the name of the plugin directory is the same as the plugin name set in the `repo.json`.

So the current `require()` will not work since it is expecting the name of the repository instead.

This can be solved by trying both names (repo name and plugin name) for the `require()` function